### PR TITLE
fix: hlint cleanups in Chart.Parse

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,5 @@
 packages:
   chart-svg.cabal
-  ../circuits-parser/circuits-parser.cabal
-  ../circuits/circuits.cabal
 
 write-ghc-environment-files: always
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,7 @@
 packages:
   chart-svg.cabal
+  ../circuits-parser/circuits-parser.cabal
+  ../circuits/circuits.cabal
 
 write-ghc-environment-files: always
 

--- a/cabal.project
+++ b/cabal.project
@@ -4,10 +4,4 @@ packages:
 write-ghc-environment-files: always
 
 allow-newer:
-  indexed-traversable:base,
-  indexed-traversable:containers,
-  indexed-traversable-instances:base,
-  tdigest:base,
-  these:base,
-  optics-core:containers,
-  microlens-th:template-haskell
+  tdigest:base

--- a/chart-svg.cabal
+++ b/chart-svg.cabal
@@ -87,7 +87,7 @@ library
     formatn >=0.3 && <0.4,
     harpie >=0.1 && <0.3,
     lens >=5 && <5.4,
-    markup-parse >=0.1 && <0.3,
+    circuits-parser >=0.1 && <0.2,
     mtl >=2.2.2 && <2.4,
     numhask >=0.11 && <0.14,
     numhask-space >=0.10 && <0.14,

--- a/src/Chart/Compound.hs
+++ b/src/Chart/Compound.hs
@@ -21,7 +21,7 @@ import Data.ByteString.Char8 qualified as C
 import Data.Foldable
 import Data.List qualified as List
 import Data.Maybe
-import MarkupParse
+import Circuit.Markup
 import Optics.Core
 import Prelude
 

--- a/src/Chart/Compound.hs
+++ b/src/Chart/Compound.hs
@@ -16,12 +16,12 @@ import Chart.Hud
 import Chart.Markup
 import Chart.Primitive
 import Chart.Style
+import Circuit.Markup
 import Data.Bool
 import Data.ByteString.Char8 qualified as C
 import Data.Foldable
 import Data.List qualified as List
 import Data.Maybe
-import Circuit.Markup
 import Optics.Core
 import Prelude
 

--- a/src/Chart/Markup.hs
+++ b/src/Chart/Markup.hs
@@ -36,6 +36,7 @@ import Chart.Data
 import Chart.Hud
 import Chart.Primitive hiding (tree)
 import Chart.Style
+import Circuit.Markup
 import Data.Bool
 import Data.ByteString (ByteString, intercalate, writeFile)
 import Data.Colour
@@ -48,7 +49,6 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import GHC.Generics
-import Circuit.Markup
 import NumHask.Space
 import Optics.Core hiding (element)
 import Prelude

--- a/src/Chart/Markup.hs
+++ b/src/Chart/Markup.hs
@@ -48,7 +48,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import GHC.Generics
-import MarkupParse
+import Circuit.Markup
 import NumHask.Space
 import Optics.Core hiding (element)
 import Prelude
@@ -65,7 +65,7 @@ localStrToUtf8 = encodeUtf8 . T.pack
 -- >>> import Optics.Core
 -- >>> let c0 = ChartOptions (defaultMarkupOptions & #cssOptions % #preferColorScheme .~ PreferNormal) mempty mempty
 -- >>> import Chart.Examples
--- >>> import MarkupParse
+-- >>> import Circuit.Markup
 
 -- | Show a Double, or rounded to 4 decimal places if this is shorter.
 --
@@ -142,7 +142,7 @@ markupRect (Rect x z y w) =
 
 -- | Convert a Chart to Markup
 --
--- >>> import MarkupParse
+-- >>> import Circuit.Markup
 -- >>> import Optics.Core
 -- >>> import Control.Category ((>>>))
 -- >>> lineExample & toListOf (#chartTree % charts') & mconcat & fmap (markupChart >>> markdown_ Compact Xml)

--- a/src/Chart/Parse.hs
+++ b/src/Chart/Parse.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | Simple parser implementation to replace flatparse
 module Chart.Parse
@@ -67,7 +65,7 @@ instance Monad (Parser e) where
     Err e -> Err e
 
 instance Alternative (Parser e) where
-  empty = Parser $ \_ -> Fail
+  empty = Parser $ const Fail
   Parser p <|> Parser q = Parser $ \s -> case p s of
     Fail -> q s
     ok -> ok


### PR DESCRIPTION
## What

- Remove unused `LambdaCase` and `OverloadedStrings` LANGUAGE pragmas
- Use `const` instead of `\_ -> Fail`

## Verification

```
ormolu: ok
hlint: no hints
cabal build all: ok
```